### PR TITLE
Change Config.hpp to Constants.hpp

### DIFF
--- a/project/interface/src-gen/v1/com/ivis/AVInformationProvider/AVInformationSomeIPStubAdapter.hpp
+++ b/project/interface/src-gen/v1/com/ivis/AVInformationProvider/AVInformationSomeIPStubAdapter.hpp
@@ -23,7 +23,7 @@
 #include <CommonAPI/SomeIP/StubAdapter.hpp>
 #include <CommonAPI/SomeIP/Factory.hpp>
 #include <CommonAPI/SomeIP/Types.hpp>
-#include <CommonAPI/SomeIP/Config.hpp>
+#include <CommonAPI/SomeIP/Constants.hpp>
 
 #undef COMMONAPI_INTERNAL_COMPILATION
 

--- a/project/interface/src-gen/v1/com/ivis/CDL/ClientAPIRemoteSomeIPStubAdapter.hpp
+++ b/project/interface/src-gen/v1/com/ivis/CDL/ClientAPIRemoteSomeIPStubAdapter.hpp
@@ -23,7 +23,7 @@
 #include <CommonAPI/SomeIP/StubAdapter.hpp>
 #include <CommonAPI/SomeIP/Factory.hpp>
 #include <CommonAPI/SomeIP/Types.hpp>
-#include <CommonAPI/SomeIP/Config.hpp>
+#include <CommonAPI/SomeIP/Constants.hpp>
 
 #undef COMMONAPI_INTERNAL_COMPILATION
 


### PR DESCRIPTION
[common-api-c++-someip changes]
Removed Config.hpp. The defines of this file are now located in
Constants.hpp

[GDP-665] Fix build error in cdl-concept-demo

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>